### PR TITLE
Fixed FastaToVCFCounts import #7

### DIFF
--- a/cflib/cf.py
+++ b/cflib/cf.py
@@ -757,7 +757,7 @@ class CFWriter():
                 snpL.append(None)
         while True:
             if snpL == [None] * self.nV:
-                raise StopIteration()
+                return
             for i in range(self.nV):
                 if snpL[i] is not None:
                     minPos = snpL[i].pos

--- a/cflib/vcf.py
+++ b/cflib/vcf.py
@@ -179,8 +179,12 @@ class NucBase():
     def set_ploidy(self):
         """Set self.ploidy."""
         baseInfo = self.speciesData[0].split(':')[0]
-        # FIXME: Also split '|'.
-        self.ploidy = len(baseInfo.split('/'))
+        if '/' in baseInfo:
+            self.ploidy = len(baseInfo.split('/'))
+        elif '|' in baseInfo:
+            self.ploidy = len(baseInfo.split('|'))
+        else:
+            self.ploidy = 1
         return self.ploidy
 
     def get_speciesData(self):
@@ -210,8 +214,12 @@ class NucBase():
             else:
                 # Diploid or even more
                 baseInfo = self.speciesData[i].split(':')[0]
-                # FIXME: Also split '|'.
-                baseInfoL = baseInfo.split('/')
+                if '/' in baseInfo:
+                    baseInfoL = baseInfo.split('/')
+                elif '|' in baseInfo:
+                    baseInfoL = baseInfo.split('|')
+                else:
+                    baseInfoL = baseInfo
                 for j in range(len(baseInfoL)):
                     try:
                         baseInfoL[j] = int(baseInfoL[j])

--- a/scripts/FastaVCFToCounts.py
+++ b/scripts/FastaVCFToCounts.py
@@ -107,7 +107,7 @@ faR = fa.init_seq(fastaRef)
 if offset is None:
     rg = faR.seq.get_region_no_description()
 else:
-    rg = faR.seq.get_region_no_description(offset)
+    rg = faR.seq.get_region_no_description(int(offset[0]))
 
 cfw.set_seq(faR.seq)
 cfw.write_HLn()


### PR DESCRIPTION
Removed `raise StopIteration()` in cf.py line 760 to prevent 'RuntimeError: generator raised StopIteration'. Added split by '/' or '|' for polyploid VCF. Added conversion of offset argument to int in FastaVCFToCounts.